### PR TITLE
Fixes time millis

### DIFF
--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -99,7 +99,7 @@ module Fluent
         end
 
         # Use the recorded event time if available
-        time = Fluent::EventTime.new(record.delete('timestamp').to_f ) if record.key?('timestamp')
+        time = Fluent::EventTime.from_time(Time.at(record.delete('timestamp').to_f) ) if record.key?('timestamp')
 
         # Postprocess recorded event
         strip_leading_underscore_(record) if @strip_leading_underscore


### PR DESCRIPTION
When this input plugin will use some others output plugins like GELF for example the time calculation in this outputs plugins are based in the Fluent::TimeEvent format so we need to provide a properly formatted time field